### PR TITLE
Address the discrepancy of New AutoSarima

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,39 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: docs
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        sudo apt-get install openjdk-11-jdk
+        sudo apt-get install pandoc
+        pip install merlion/[plot]
+        pip install -e ts_datasets/
+    - name: Build Sphinx docs
+      run: |
+        cd docs
+        pip install -r requirements.txt
+        make clean html
+        cd ..
+    - name: Deploy to gh-pages
+      uses: peaceiris/actions-gh-pages@v3
+      if: ${{ github.ref == 'refs/heads/main' }}
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: docs/build/html

--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,4 @@ Icon?
 # build files
 docs/build/*
 .ipynb_checkpoints
-
 venv/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ that the model is behaving as expected.
 
 Finally, update the API docs by
 -   Adding your new module to the autosummary block of the appropriate `__init__.py`
-    (e.g. [`merlion/models/anomaly/__init__.py`](merlion/models/anomaly/__init__.py) for an anomaly detector)
+    (e.g. [`merlion/models/anomaly/__init__.py`](merlion/merlion/models/anomaly/__init__.py) for an anomaly detector)
 -   Adding your new module to the appropriate Sphinx ReST file (e.g. 
     [`docs/source/merlion.models.anomaly.rst`](docs/source/merlion.models.anomaly.rst) for an anomaly detector)
 
@@ -56,8 +56,8 @@ You may optionally override the following class variables of `ConfigClass` or `M
     default config to train the post-rule (e.g. select the minimum anomaly score we want to set as a detection
     threshold).
 
-See our implementation of [Isolation Forest](merlion/models/anomaly/isolation_forest.py) for a fairly simple example of
-what this looks like in practice, and this [notebook](examples/anomaly/AnomalyNewModel.ipynb) for a step-by-step
+See our implementation of [Isolation Forest](merlion/merlion/models/anomaly/isolation_forest.py) for a fairly simple example of
+what this looks like in practice, and this [notebook](examples/anomaly/3_AnomalyNewModel.ipynb) for a step-by-step
 walkthrough of a minimal example.
 
 ### Forecasters
@@ -80,7 +80,7 @@ You may optionally override the class variable `ConfigClass._default_transform`.
 transform used to process the data before giving it to the model, if the `transform` keyword argument is not
 given when initializing the config.
 
-See our implementation of [SARIMA](merlion/models/forecast/sarima.py) for a fairly simple example of what this looks
+See our implementation of [SARIMA](merlion/merlion/models/forecast/sarima.py) for a fairly simple example of what this looks
 like in practice, and this [notebook](examples/forecast/ForecastNewModel.ipynb) for a step-by-step walkthrough of a
 minimal example.
 
@@ -97,9 +97,9 @@ this class into an `ForecasterDetectorClass`. You need to do the following thing
 -   Implement a model class which inherits from both `ForecastingDetectorBase` and `ForecasterClass` (in that order).
     You may optionally override the `_default_post_rule_train_config` class variable.
 
-See our implementation of a [Prophet-based anomaly detector](merlion/models/anomaly/forecast_based/prophet.py) for an
+See our implementation of a [Prophet-based anomaly detector](merlion/merlion/models/anomaly/forecast_based/prophet.py) for an
 example of what this looks like in practice, as well as the forecaster tutorial 
-[notebook](examples/forecast/ForecastNewModel.ipynb).
+[notebook](examples/forecast/3_ForecastNewModel.ipynb).
 
 ## Data Pre-Processing Transforms
 To implement a new data pre-processing transform, begin by reading the [API docs](docs) for the base classes
@@ -112,7 +112,7 @@ However, we can approximate the desired inversion by keeping track of the origin
 
 To actually implement a transform, override the abstract methods `train()` (this may be a no-op for
 transforms with no data-dependent parameters), `__call__()` (actually applying the transform), and `_invert` (inverting
-or pseudo-inverting the transform). Then, register it with the [transform factory](merlion/transform/factory.py).
+or pseudo-inverting the transform). Then, register it with the [transform factory](merlion/merlion/transform/factory.py).
 
 Specify the class property `requires_inversion_state` to indicate whether the inversion (or pseudo-inversion) is
 stateless (e.g. `merlion.transform.Rescale` simply rescales an input by a fixed scale and bias) or stateful
@@ -121,11 +121,11 @@ series, since these are discarded by the forward transform). If the transform re
 `self.inversion_state` in the `__call__()` method and use it as needed in the `_invert()` method. Note that the
 inversion state can have whatever data format is most suitable for your purposes.
 
-Check the implementations of [`DifferenceTransform`](merlion/transform/moving_average.py#L139),
-[`PowerTransform`](merlion/transform/normalize.py#L123), and [`LowerUpperClip`](merlion/transform/bound.py)
+Check the implementations of [`DifferenceTransform`](merlion/merlion/transform/moving_average.py#L139),
+[`PowerTransform`](merlion/merlion/transform/normalize.py#L123), and [`LowerUpperClip`](merlion/merlion/transform/bound.py)
 for a few examples. Add your transforms to whatever module you feel is most appropriate, or create a new file if it
 doesn't fit in with any of the existing ones. However, if you do add a new file, make sure to add it to the API docs
-by updating the autosummary block of [`merlion/transform/__init__.py`](merlion/transform/__init__.py), and adding the
+by updating the autosummary block of [`merlion/transform/__init__.py`](merlion/merlion/transform/__init__.py), and adding the
 new module to the Sphinx ReST file [`docs/source/merlion.transform.rst`](docs/source/merlion.transform.rst). 
 
 ## Datasets

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -5,9 +5,15 @@
 
 Welcome to Merlion's documentation!
 ===================================
-Merlion consists of two sub-repos: :py:mod:`merlion`, which is a repo for time series analysis, focusing on
-anomaly detection and forecasting, and :py:mod:`ts_datasets`, a repo which implements data loaders for multiple time
-series datasets, which loads time series as ``pandas.DataFrame`` s with accompanying metadata.
+Merlion is a Python library for time series intelligence. It provides an end-to-end machine
+learning framework that includes loading and transforming data, building and training models,
+post-processing model outputs, and evaluating model performance. It supports various time series
+learning tasks, including forecasting and anomaly detection for both univariate and multivariate
+time series. It also contains ensemble learning and autoML modules.
+
+Merlion consists of two sub-packages: :py:mod:`merlion` implements the library's core time series intelligence features,
+and :py:mod:`ts_datasets` provides standardized data loaders for multiple time series datasets that loads time series as
+``pandas.DataFrame`` s with accompanying metadata.
 
 You can install :py:mod:`merlion` from PyPI by calling ``pip install sfdc-merlion``. You may install from source by
 cloning this repo, navigating to the root directory, and calling ``pip install [-e] merlion/``. We recommend
@@ -39,9 +45,9 @@ and `forecasting <examples/forecast/0_ForecastIntro>`.
    :maxdepth: 2
    :caption: Contents:
 
-   tutorials
    merlion
    ts_datasets
+   tutorials
 
 
 Indices and tables

--- a/docs/source/merlion.rst
+++ b/docs/source/merlion.rst
@@ -1,10 +1,10 @@
-merlion package
-===============
-:py:mod:`merlion` is a repo for time series anomaly detection and forecasting. We support the following key features,
+merlion: Time Series Intelligence
+=================================
+:py:mod:`merlion` is a Python library for time series intelligence. We support the following key features,
 each associated with its own sub-package:
 
 -   :py:mod:`merlion.models`: A library of models unified under a single shared interface, with specializations
-    for anomaly detection and forecasting, respectively. More specifically, we have
+    for anomaly detection and forecasting. More specifically, we have
 
     -   :py:mod:`merlion.models.anomaly`: Anomaly detection models
     -   :py:mod:`merlion.models.forecast`: Forecasting models

--- a/docs/source/ts_datasets.rst
+++ b/docs/source/ts_datasets.rst
@@ -1,5 +1,26 @@
-ts_datasets package
-===================
+ts_datasets: Easy Data Loading
+==============================
+
+:py:mod:`ts_datasets` implements Python classes that manipulate numerous time series datasets
+into standardized ``pandas.DataFrame`` s. The sub-modules are :py:mod:`ts_datasets.anomaly`
+for time series anomaly detection, and :py:mod:`ts_datasets.forecast` for time series forecasting.
+Simply install the package by calling ``pip install -e ts_datasets/`` from the root directory of Merlion.
+Then, you can load a dataset (e.g. the "realAWSCloudwatch" split of the Numenta Anomaly Benchmark
+or the "Hourly" subset of the M4 dataset) by calling
+
+.. code-block:: python
+
+    from ts_datasets.anomaly import NAB
+    from ts_datasets.forecast import M4
+    anom_dataset = NAB(subset="realAWSCloudwatch", rootdir=path_to_NAB)
+    forecast_dataset = M4(subset="Hourly", rootdir=path_to_M4)
+
+If you install this package in editable mode (i.e. specify ``-e`` when calling ``pip install -e ts_datasets/``),
+there is no need to specify a ``rootdir`` for any of the data loaders.
+
+The core features of general data loaders (e.g. for forecasting) are outlined in the API doc for
+:py:class:`ts_datasets.base.BaseDataset`, and the features for time series anomaly detection data loaders
+are outlined in the API doc for :py:class:`ts_datasets.anomaly.TSADBaseDataset`.
 
 .. automodule:: ts_datasets
    :members:

--- a/tests/forecast/test_autosarima.py
+++ b/tests/forecast/test_autosarima.py
@@ -784,7 +784,8 @@ class TestAutoSarima(unittest.TestCase):
         self.model = SeasonalityLayer(
             model=AutoSarima(
                 model=Sarima(
-                    AutoSarimaConfig(
+                    AutoSarimaConfig(order=(15, "auto", 5),
+                           seasonal_order=(2, "auto", 1, "auto"),
                         max_forecast_steps=self.max_forecast_steps, maxiter=5
                     )
                 )
@@ -792,7 +793,7 @@ class TestAutoSarima(unittest.TestCase):
         )
 
     def test_forecast(self):
-        # sMAPE = 3.4491
+        # sMAPE = 3.1810 with pqPQ
         train_pred, train_err = self.model.train(
             self.train_data,
             train_config={

--- a/ts_datasets/README.md
+++ b/ts_datasets/README.md
@@ -1,21 +1,21 @@
 # ts_datasets
 This library implements Python classes that manipulate numerous time series datasets
-into standardized `pandas` DataFrames. The sub-modules are `datasets.anomaly` for time series anoamly detection, and
-`datasets.forecast` for time series forecasting. Simply install the package by calling `pip install -e .` from the
+into standardized `pandas` DataFrames. The sub-modules are `ts_datasets.anomaly` for time series anomaly detection, and
+`ts_datasets.forecast` for time series forecasting. Simply install the package by calling `pip install -e .` from the
 command line. Then, you can load a dataset (e.g. the "realAWSCloudwatch" split of the Numenta Anomaly Benchmark) by
 calling
 ```python
 from ts_datasets.anomaly import NAB
-dataset = NAB(subset="realAWSCloudwatch", rootdir=<your_rootdir>)
+dataset = NAB(subset="realAWSCloudwatch", rootdir=path_to_NAB)
 ```
 Note that if you have installed this package in editable mode (i.e. by specifying `-e`), the root directory
 need not be specified.
 
 Each dataset supports the following features: 
 1.  ``__getitem__``: you may call ``ts, metadata = dataset[i]``. ``ts`` is a time-indexed ``pandas`` DataFrame, with
-    each column representing a different variable (in the case of multivariate time series). ``metadata`` is a
-    ``pandas`` DataFrame with the same index as ``ts``, with different columns indicating different dataset-specific
-    metadata (train/test split, anomaly labels, etc.) for each timestamp. 
+    each column representing a different variable (in the case of multivariate time series). ``metadata`` is a dict or
+    ``pd.DataFrame`` with the same index as ``ts``, with different keys indicating different dataset-specific
+    metadata (train/test split, anomaly labels, etc.) for each timestamp.
 2.  ``__len__``:  Calling ``len(dataset)`` will return the number of time series in the dataset.
 3.  ``__iter__``: You may iterate over the `pandas` representations of the time series in the dataset with
     ``for ts, metadata in dataset: ...``

--- a/ts_datasets/ts_datasets/anomaly/base.py
+++ b/ts_datasets/ts_datasets/anomaly/base.py
@@ -11,8 +11,8 @@ _extra_note = """
 
 .. note::
 
-    For each time series, the ``metadata`` data frame has a ``bool`` column
-    ``anomaly``, indicating whether each timestamp is anomalous.
+    For each time series, the ``metadata`` will always have the key ``anomaly``, which is a 
+    ``pd.Series`` of ``bool`` indicating whether each timestamp is anomalous.
 """
 
 

--- a/ts_datasets/ts_datasets/base.py
+++ b/ts_datasets/ts_datasets/base.py
@@ -6,22 +6,19 @@ _intro_docstr = "Base dataset class for storing time series as ``pd.DataFrame``Â
 _main_fns_docstr = """
 Each dataset supports the following features:
 
-1.  ``__getitem__``: you may call ``ts, metadata = dataset[i]``. ``ts`` is a
-    time-indexed ``pd.DataFrame``, with each column representing a different
-    variable (in the case of multivariate time series). ``metadata`` is a
-    ``pandas`` DataFrame with the same index as ``ts``, with different columns
-    indicating different dataset-specific metadata (train/test split, anomaly
-    labels, etc.) for each timestamp. 
-2.  ``__len__``:  Calling ``len(dataset)`` will return the number of time series
-    in the dataset.
-3.  ``__iter__``: You may iterate over the ``pandas`` representations of the
-    time series in the dataset with ``for ts, metadata in dataset: ...``
+1.  ``__getitem__``: you may call ``ts, metadata = dataset[i]``. ``ts`` is a time-indexed ``pandas`` DataFrame, with
+    each column representing a different variable (in the case of multivariate time series). ``metadata`` is a dict or
+    ``pd.DataFrame`` with the same index as ``ts``, with different keys indicating different dataset-specific
+    metadata (train/test split, anomaly labels, etc.) for each timestamp.
+2.  ``__len__``:  Calling ``len(dataset)`` will return the number of time series in the dataset.
+3.  ``__iter__``: You may iterate over the ``pandas`` representations of the time series in the dataset with
+    ``for ts, metadata in dataset: ...``
 
 .. note::
 
-    For each time series, the ``metadata`` data frame has a ``bool`` column
-    ``trainval``, indicating whether each timestamp is for training/validation
-    (if ``True``) or for testing (if ``False``).
+    For each time series, the ``metadata`` will always have the key ``trainval``, which is a 
+    ``pd.Series`` of ``bool`` indicating whether each timestamp of the time series should be
+    training/validation (if ``True``) or testing (if ``False``). 
 """
 
 


### PR DESCRIPTION
1. pass `enforce_stationarity=False` and `enforce_invertibility=False` to model training
2. support approximation iteration for speedup
3. support detection of optimal max_iter
4. Wrap up a Sarima class after stepwise search 

Questions to @paulkass:
1.  In `forecasting_layer_base.py` line 39-61, why the method invoke the `self.generate_theta(train_data)` and `self.evaluate_theta(candidate_thetas, original_train_data, train_config)` in super class first, then invoke these two methods in `autosarima.py` again? Could you elaborate more on your comments "need to call evaluate_theta on original training data since evaluate_theta often trains another model and therefore we might be applying transform twice"?
2. In `autosarima.py`, why invoke `self._generate_sarima_parameters(train_data)` in both `evaluate_theta` and `generate_theta`. This causes the duplicate logs about `seasonal difference order` and `difference order`.  
Again, another duplicate log could be found from sarima.py.

![image](https://user-images.githubusercontent.com/74166079/131247244-06ca081b-dffc-4d1f-9d6c-c4b53ceb5a9a.png)

