### PR TITLE
Fix boundary condition bug in resampling code.

### DIFF
--- a/tests/evaluate/test_eval_anomaly.py
+++ b/tests/evaluate/test_eval_anomaly.py
@@ -82,7 +82,7 @@ class TestEvaluateAnomaly(unittest.TestCase):
     def test_ensemble_with_valid(self):
         print("-" * 80)
         logger.info("test_ensemble_with_valid\n" + "-" * 80 + "\n")
-        model = self.run_ensemble(valid_frac=0.50, expected_precision=9 / 60, expected_recall=9 / 9)
+        model = self.run_ensemble(valid_frac=0.50, expected_precision=9 / 59, expected_recall=9 / 9)
         self.assertSequenceEqual(model.combiner.models_used, [False, True, False])
 
         # Do a quick test of saving/loading

--- a/tests/forecast/test_forecast_ensemble.py
+++ b/tests/forecast/test_forecast_ensemble.py
@@ -58,7 +58,7 @@ class TestForecastEnsemble(unittest.TestCase):
         self.run_test()
         # We expect the model selector to select Prophet because it gets the lowest validation sMAPE
         valid_smapes = np.asarray(self.ensemble.combiner.metric_values)
-        self.assertAlmostEqual(np.max(np.abs(valid_smapes - [34.65, 39.62, 30.71])), 0, delta=0.5)
+        self.assertAlmostEqual(np.max(np.abs(valid_smapes - [34.32, 40.66, 30.71])), 0, delta=0.5)
         self.assertSequenceEqual(self.ensemble.models_used, [False, False, True])
 
     def run_test(self):


### PR DESCRIPTION
In certain cases, the resampling code would copy the last value of the time series to the next timestamp. This PR fixes that bug.