### PR TITLE
Change default min_likelihood to 1e-16 for BOCPD

### DIFF
--- a/merlion/models/anomaly/change_point/bocpd.py
+++ b/merlion/models/anomaly/change_point/bocpd.py
@@ -95,7 +95,7 @@ class BOCPDConfig(ForecasterConfig, NoCalibrationDetectorConfig):
         change_kind: Union[str, ChangeKind] = ChangeKind.Auto,
         cp_prior=1e-2,
         lag=None,
-        min_likelihood=1e-12,
+        min_likelihood=1e-16,
         max_forecast_steps=None,
         **kwargs,
     ):


### PR DESCRIPTION
Tested the BOCPD on some time series I have, and @aadyotb  and I found out 1e-16 to be a better value for min_likelihood. The screenshot below showed the forecast value using 1e-12 (default) vs 1e-16.
![1e-12](https://user-images.githubusercontent.com/31741624/153306256-404a141c-6f98-4998-b25d-d8695e67639d.png)
![1e-16](https://user-images.githubusercontent.com/31741624/153306277-9e815b73-d7e0-45d4-a5e0-1d4b31691755.png)

