### PR TITLE
Fix AutoSARIMA bugs.

### DIFF
--- a/merlion/models/automl/autosarima.py
+++ b/merlion/models/automl/autosarima.py
@@ -357,7 +357,7 @@ class AutoSarima(SeasonalityLayer):
             )
 
         else:
-            return theta_value, None, None
+            return theta_value["theta"], None, None
 
         model = deepcopy(self.model)
         model.reset()

--- a/merlion/models/forecast/sarima.py
+++ b/merlion/models/forecast/sarima.py
@@ -142,11 +142,11 @@ class Sarima(ForecasterBase, SeasonalityModel):
                 err = np.zeros(len(time_stamps))
 
             if return_prev:
-                n_prev = len(time_series_prev)
+                m = len(time_series_prev) - len(val_prev)
                 params = dict(zip(new_state.param_names, new_state.params))
-                err_prev = np.sqrt(params["sigma2"])
-                forecast = np.concatenate((val_prev - new_state.resid, forecast))
-                err = np.concatenate((err_prev * np.ones(n_prev), err))
+                err_prev = np.concatenate((np.zeros(m), np.full(len(val_prev), np.sqrt(params["sigma2"]))))
+                forecast = np.concatenate((time_series_prev.values[:m], val_prev - new_state.resid, forecast))
+                err = np.concatenate((err_prev, err))
                 time_stamps = np.concatenate((t_prev, time_stamps))
 
         # Check for NaN's

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ def read_file(fname):
 
 setup(
     name="salesforce-merlion",
-    version="1.2.1",
+    version="1.2.2",
     author=", ".join(read_file("AUTHORS.md").split("\n")),
     author_email="abhatnagar@salesforce.com",
     description="Merlion: A Machine Learning Framework for Time Series Intelligence",


### PR DESCRIPTION
This PR fixes two bugs:
1. `AutoSarima.evaluate_theta` returns a dict instead of a tuple in a specific case.
2. `Sarima._forecast` doesn't always work as expected when `return_prev` is `True` and the MA order is 0.