### PR TITLE
Don't resample timestamps if not needed.

### DIFF
--- a/merlion/models/forecast/base.py
+++ b/merlion/models/forecast/base.py
@@ -119,6 +119,10 @@ class ForecasterBase(ModelBase):
             tf = resampled[-1]
             time_stamps = to_timestamp(resampled)
 
+        elif not self.require_even_sampling:
+            resampled = to_pd_datetime(time_stamps)
+            tf = resampled[-1]
+
         # Handle the cases where we don't have a max_forecast_steps
         elif self.max_forecast_steps is None:
             tf = to_pd_datetime(time_stamps[-1])


### PR DESCRIPTION
Merlion forecasters have a property `requires_even_sampling`, which determines whether they should resample input timestamps. The changes in 1.2.0 made it so the timestamps would always be resampled, even if `requires_even_sampling=False`. This PR ensures this option is actually respected.