### PR TITLE
Various bugfixes & enhancements.

### DIFF
--- a/apps/anomaly.py
+++ b/apps/anomaly.py
@@ -93,7 +93,7 @@ def main():
     df = read_dataset(
         spark=spark,
         file_format=args.file_format,
-        path=args.train_data,
+        path=args.data,
         time_col=args.time_col,
         index_cols=args.index_cols,
         data_cols=args.data_cols,

--- a/merlion/models/base.py
+++ b/merlion/models/base.py
@@ -281,7 +281,7 @@ class ModelBase(metaclass=AutodocABCMeta):
             raise RuntimeError(
                 f"Transform {self.transform} transforms data into a {train_data.dim}-"
                 f"variate time series, but model {type(self).__name__} can "
-                f"only handle uni-variate time series. Change the transform."
+                f"only handle uni-variate time series. Change the transform or set target_seq_index."
             )
 
         t = train_data.time_stamps

--- a/merlion/models/factory.py
+++ b/merlion/models/factory.py
@@ -9,12 +9,14 @@ Contains the `ModelFactory`.
 """
 import copy
 import inspect
+import logging
 from typing import Dict, Tuple, Type, Union
 
 import dill
 from merlion.models.base import ModelBase
 from merlion.utils import dynamic_import
 
+logger = logging.getLogger(__name__)
 
 import_alias = dict(
     # Default models
@@ -107,10 +109,11 @@ class ModelFactory:
 def instantiate_or_copy_model(model: Union[dict, ModelBase]):
     if isinstance(model, ModelBase):
         return copy.deepcopy(model)
-    if isinstance(model, dict):
+    elif isinstance(model, dict):
         try:
             return ModelFactory.create(**model)
         except Exception as e:
-            raise ValueError(f"Invalid `dict` specifying a model config.\n\nGot {model}\n\nException: {e}")
+            logger.error(f"Invalid `dict` specifying a model config.\n\nGot {model}")
+            raise e
     else:
-        raise TypeError(f"Expected model to be a `dict` or `ModelBase`. Got {model}.")
+        raise TypeError(f"Expected model to be a `dict` or `ModelBase`. Got {model}")

--- a/merlion/models/forecast/trees.py
+++ b/merlion/models/forecast/trees.py
@@ -31,8 +31,8 @@ class TreeEnsembleForecasterConfig(ForecasterConfig):
 
     def __init__(
         self,
-        max_forecast_steps: int,
         maxlags: int,
+        max_forecast_steps: int = None,
         target_seq_index: int = None,
         sampling_mode: str = "normal",
         prediction_stride: int = 1,
@@ -42,8 +42,8 @@ class TreeEnsembleForecasterConfig(ForecasterConfig):
         **kwargs,
     ):
         """
-        :param max_forecast_steps: Max # of steps we would like to forecast for.
         :param maxlags: Max # of lags for forecasting
+        :param max_forecast_steps: Max # of steps we would like to forecast for.
         :param target_seq_index: The index of the univariate (amongst all
             univariates in a general multivariate time series) whose value we
             would like to forecast.
@@ -264,11 +264,11 @@ class ExtraTreesForecasterConfig(TreeEnsembleForecasterConfig):
     Config class for `ExtraTreesForecaster`.
     """
 
-    def __init__(self, max_forecast_steps: int, maxlags: int, min_samples_split=2, **kwargs):
+    def __init__(self, maxlags: int, min_samples_split=2, **kwargs):
         """
         :param min_samples_split: min split for tree leaves
         """
-        super().__init__(max_forecast_steps=max_forecast_steps, maxlags=maxlags, **kwargs)
+        super().__init__(maxlags=maxlags, **kwargs)
         self.min_samples_split = min_samples_split
 
 
@@ -299,12 +299,12 @@ class LGBMForecasterConfig(TreeEnsembleForecasterConfig):
     Config class for `LGBMForecaster`.
     """
 
-    def __init__(self, max_forecast_steps: int, maxlags: int, learning_rate=0.1, n_jobs=-1, **kwargs):
+    def __init__(self, maxlags: int, learning_rate=0.1, n_jobs=-1, **kwargs):
         """
         :param learning_rate: learning rate for boosting
         :param n_jobs: num of threading, -1 or 0 indicates device default, positive int indicates num of threads
         """
-        super().__init__(max_forecast_steps=max_forecast_steps, maxlags=maxlags, **kwargs)
+        super().__init__(maxlags=maxlags, **kwargs)
         self.learning_rate = learning_rate
         self.n_jobs = n_jobs
 

--- a/merlion/models/layers.py
+++ b/merlion/models/layers.py
@@ -115,7 +115,7 @@ class LayeredModelConfig(Config):
         return self.from_dict(config_dict)
 
     def __getattr__(self, item):
-        if item in ["model", "_model", "base_model"]:
+        if item in ["model", "base_model"]:
             return super().__getattribute__(item)
         base_model = self.base_model
         is_detector_attr = isinstance(base_model, DetectorBase) and item in _DETECTOR_MEMBERS
@@ -127,7 +127,7 @@ class LayeredModelConfig(Config):
         return self.__getattribute__(item)
 
     def __setattr__(self, key, value):
-        if hasattr(self, "_model"):
+        if hasattr(self, "model") and hasattr(self.model, "config"):
             base_model = self.base_model
             is_detector_attr = isinstance(base_model, DetectorBase) and key in _DETECTOR_MEMBERS
             is_forecaster_attr = isinstance(base_model, ForecasterBase) and key in _FORECASTER_MEMBERS

--- a/tests/forecast/test_default.py
+++ b/tests/forecast/test_default.py
@@ -183,9 +183,7 @@ class TestMultivariate(unittest.TestCase):
         self.train_data_norm = minmax_transform(train_data)
         self.test_data_norm = minmax_transform(test_data)
 
-        self.model = DefaultForecaster(
-            DefaultForecasterConfig(max_forecast_steps=self.max_forecast_steps, target_seq_index=self.i)
-        )
+        self.model = DefaultForecaster(DefaultForecasterConfig(target_seq_index=self.i))
 
     def test_forecast(self):
         logger.info("Training model...")
@@ -200,8 +198,8 @@ class TestMultivariate(unittest.TestCase):
         logger.info(f"SMAPE = {smape}")
 
         # save and load
-        self.model.save(dirname=join(rootdir, "tmp", "lgbmforecaster"))
-        loaded_model = DefaultForecaster.load(dirname=join(rootdir, "tmp", "lgbmforecaster"))
+        self.model.save(dirname=join(rootdir, "tmp", "default"))
+        loaded_model = DefaultForecaster.load(dirname=join(rootdir, "tmp", "default"))
         new_pred, _ = loaded_model.forecast(testing_label.time_stamps, testing_instance)
         new_smape = ForecastMetric.sMAPE.value(predict=new_pred, ground_truth=testing_label.to_ts())
         self.assertAlmostEqual(smape, new_smape, places=4)


### PR DESCRIPTION
This PR makes the following bugfixes and enhancements:
1. Fixes an argparse bug in the anomaly detection pyspark app.
2. Fixes a bug in layered models which prevented certain sub-model parameters from being set correctly. We also add test coverage.
3. Makes `max_forecast_steps` optional for tree models (`max_forecast_steps=None` was made to be a valid option for these models in #114).
4. Makes exceptions from `ModelFactory` more descriptive, by logging the model_dict used and also throwing the original exception. Previously, only a value error was thrown.