### PR TITLE
Make ForecastMetric work for multivariate time series.

### DIFF
--- a/merlion/models/ensemble/combine.py
+++ b/merlion/models/ensemble/combine.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021 salesforce.com, inc.
+# Copyright (c) 2022 salesforce.com, inc.
 # All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 # For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
@@ -92,7 +92,7 @@ class CombinerBase(metaclass=AutodocABCMeta):
         assert self.n_models is not None, "Combiner must be trained to determine which models are used"
         return [True] * self.n_models
 
-    def train(self, all_model_outs: List[TimeSeries], target: TimeSeries = None) -> TimeSeries:
+    def train(self, all_model_outs: List[TimeSeries], target: TimeSeries = None, **kwargs) -> TimeSeries:
         """
         Trains the model combination rule.
 

--- a/merlion/models/ensemble/forecast.py
+++ b/merlion/models/ensemble/forecast.py
@@ -96,6 +96,9 @@ class ForecasterEnsemble(EnsembleBase, ForecasterBase):
     def resample_time_stamps(self, time_stamps: Union[int, List[int]], time_series_prev: TimeSeries = None):
         return time_stamps
 
+    def train_combiner(self, all_model_outs: List[TimeSeries], target: TimeSeries, **kwargs) -> TimeSeries:
+        return self.combiner.train(all_model_outs, target, target_seq_index=self.target_seq_index)
+
     def _train(
         self, train_data: pd.DataFrame, train_config: EnsembleTrainConfig = None
     ) -> Tuple[Optional[TimeSeries], None]:

--- a/tests/forecast/test_forecast_ensemble.py
+++ b/tests/forecast/test_forecast_ensemble.py
@@ -10,6 +10,7 @@ import sys
 import unittest
 
 import numpy as np
+import pandas as pd
 
 from merlion.models.ensemble.forecast import ForecasterEnsemble, ForecasterEnsembleConfig
 from merlion.models.ensemble.combine import ModelSelector, Mean
@@ -19,7 +20,7 @@ from merlion.models.forecast.arima import Arima, ArimaConfig
 from merlion.models.factory import ModelFactory
 from merlion.transform.base import Identity
 from merlion.transform.resample import TemporalResample
-from merlion.utils.data_io import csv_to_time_series
+from merlion.utils.data_io import csv_to_time_series, TimeSeries
 
 logger = logging.getLogger(__name__)
 rootdir = dirname(dirname(dirname(abspath(__file__))))
@@ -37,13 +38,12 @@ class TestForecastEnsemble(unittest.TestCase):
     def test_mean(self):
         print("-" * 80)
         model0 = Arima(ArimaConfig(order=(6, 1, 2), max_forecast_steps=50, transform=TemporalResample("1h")))
-        model1 = Arima(ArimaConfig(order=(24, 1, 0), transform=TemporalResample("10min"), max_forecast_steps=50))
+        model1 = Arima(ArimaConfig(order=(24, 1, 0), max_forecast_steps=50, transform=TemporalResample("10min")))
         model2 = AutoProphet(
             config=AutoProphetConfig(transform=Identity(), periodicity_strategy=PeriodicityStrategy.Max)
         )
         self.ensemble = ForecasterEnsemble(
-            models=[model0, model1, model2],
-            config=ForecasterEnsembleConfig(combiner=Mean(abs_score=False), target_seq_index=0),
+            models=[model0, model1, model2], config=ForecasterEnsembleConfig(combiner=Mean(abs_score=False))
         )
 
         self.expected_smape = 37
@@ -52,25 +52,35 @@ class TestForecastEnsemble(unittest.TestCase):
         logger.info("test_mean\n" + "-" * 80 + "\n")
         self.run_test()
 
-    def test_selector(self):
-        print("-" * 80)
+    def _test_selector(self):
         model0 = Arima(ArimaConfig(order=(6, 1, 2), max_forecast_steps=50, transform=TemporalResample("1h")))
         model1 = Arima(ArimaConfig(order=(24, 1, 0), transform=TemporalResample("10min"), max_forecast_steps=50))
         model2 = AutoProphet(
             config=AutoProphetConfig(target_seq_index=0, transform=Identity(), periodicity_strategy="Max")
         )
         self.ensemble = ForecasterEnsemble(
-            models=[model0, model1, model2], config=ForecasterEnsembleConfig(combiner=Mean(abs_score=False))
+            config=ForecasterEnsembleConfig(
+                models=[model0, model1, model2], combiner=ModelSelector(metric=ForecastMetric.sMAPE), target_seq_index=0
+            )
         )
-
         self.expected_smape = 35
-        logger.info("test_selector\n" + "-" * 80 + "\n")
-        self.ensemble.config.combiner = ModelSelector(metric=ForecastMetric.sMAPE)
         self.run_test()
         # We expect the model selector to select Prophet because it gets the lowest validation sMAPE
         valid_smapes = np.asarray(self.ensemble.combiner.metric_values)
         self.assertAlmostEqual(np.max(np.abs(valid_smapes - [34.32, 40.66, 30.71])), 0, delta=0.5)
         self.assertSequenceEqual(self.ensemble.models_used, [False, False, True])
+
+    def test_univariate_selector(self):
+        print("-" * 80)
+        logger.info("test_univariate_selector\n" + "-" * 80 + "\n")
+        self._test_selector()
+
+    def test_multivariate_selector(self):
+        x = self.vals_train.to_pd()
+        self.vals_train = TimeSeries.from_pd(
+            pd.DataFrame(np.concatenate((x.values, x.values * 2), axis=1), columns=["A", "B"], index=x.index)
+        )
+        self._test_selector()
 
     def run_test(self):
         logger.info("Training model...")


### PR DESCRIPTION
We add a `target_seq_index` parameter to the `ForecastScoreAccumulator`, which allows a univariate prediction to be automatically compared against a potentially multivariate ground truth.