### PR TITLE
Make _resolve_args() stateless for layered models.

### DIFF
--- a/merlion/models/layers.py
+++ b/merlion/models/layers.py
@@ -210,6 +210,9 @@ class LayeredModel(ModelBase, metaclass=AutodocABCMeta):
             )
         elif config is not None and model is not None:
             if config.model is None:
+                if isinstance(model, dict):
+                    model = ModelFactory.create(**model)
+                config = copy.copy(config)
                 config.model = model
             else:
                 raise RuntimeError(

--- a/tests/forecast/test_autosarima.py
+++ b/tests/forecast/test_autosarima.py
@@ -14,8 +14,8 @@ import pandas as pd
 
 from merlion.evaluate.forecast import ForecastMetric
 from merlion.models.automl.autosarima import AutoSarima, AutoSarimaConfig
-from merlion.models.automl.seasonality import SeasonalityLayer
-from merlion.utils import TimeSeries, autosarima_utils
+from merlion.models.automl.seasonality import SeasonalityLayer, SeasonalityConfig
+from merlion.utils import TimeSeries
 
 logger = logging.getLogger(__name__)
 rootdir = dirname(dirname(dirname(abspath(__file__))))
@@ -801,7 +801,7 @@ class TestAutoSarima(unittest.TestCase):
             )
         )
         if seasonality_layer:
-            self.model = SeasonalityLayer(model=model)
+            self.model = SeasonalityLayer(config=SeasonalityConfig(model=None), model=model)
         else:
             self.model = model
 
@@ -850,12 +850,12 @@ class TestAutoSarima(unittest.TestCase):
     def test_autosarima(self):
         print("-" * 80)
         logger.info("TestAutoSarima.test_autosarima\n" + "-" * 80 + "\n")
-        self.run_test(auto_pqPQ=False, seasonality_layer=True, expected_sMAPE=3.4130)
+        self.run_test(auto_pqPQ=False, seasonality_layer=False, expected_sMAPE=3.4130)
 
     def test_seasonality_layer(self):
         print("-" * 80)
         logger.info("TestAutoSarima.test_seasonality_layer\n" + "-" * 80 + "\n")
-        self.run_test(auto_pqPQ=False, seasonality_layer=False, expected_sMAPE=3.4130)
+        self.run_test(auto_pqPQ=False, seasonality_layer=True, expected_sMAPE=3.4130)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The current implementation of layered models fails if `config.model` is `None` but `model` is not `None` when initializing a layered model. This commit fixes the issue by ensuring that `__new__()` does not implicitly update the config object when setting model's class.