### PR TITLE
Add exogenous regressor support to sklearn models.

### DIFF
--- a/merlion/models/forecast/base.py
+++ b/merlion/models/forecast/base.py
@@ -504,11 +504,7 @@ class ForecasterBase(ModelBase):
         if time_series_prev is not None and plot_time_series_prev:
             if not self.invert_transform:
                 time_series_prev = self.transform(time_series_prev)
-            assert time_series_prev.dim == 1, (
-                f"Plotting only supported for univariate time series, but got a"
-                f"time series of dimension {time_series_prev.dim}"
-            )
-            time_series_prev = time_series_prev.univariates[time_series_prev.names[0]]
+            time_series_prev = time_series_prev.univariates[time_series_prev.names[self.target_seq_index]]
 
             n_prev = len(time_series_prev)
             yhat_prev, yhat = yhat[:n_prev], yhat[n_prev:]

--- a/merlion/models/utils/rolling_window_dataset.py
+++ b/merlion/models/utils/rolling_window_dataset.py
@@ -8,7 +8,7 @@ import logging
 import numpy as np
 from typing import Optional, Union
 import pandas as pd
-from merlion.utils.time_series import TimeSeries
+from merlion.utils.time_series import TimeSeries, to_pd_datetime
 
 logger = logging.getLogger(__name__)
 
@@ -20,6 +20,7 @@ class RollingWindowDataset:
         target_seq_index: Optional[int],
         n_past: int,
         n_future: int,
+        exog_data: Union[TimeSeries, pd.DataFrame] = None,
         shuffle: bool = False,
         ts_index: bool = False,
         batch_size: Optional[int] = 1,
@@ -46,7 +47,9 @@ class RollingWindowDataset:
             use the time series for 1-step autoregressive prediction.
         :param n_past: number of steps for past
         :param n_future: number of steps for future. If ``target_seq_index = None``, we manually set ``n_future = 1``.
-        :param shuffle: whether the windows of the time series should be shuffled
+        :param exog_data: exogenous data to as inputs for the model, but not as outputs to predict.
+            We assume the future values of exogenous variables are known a priori at test time.
+        :param shuffle: whether the windows of the time series should be shuffled.
         :param ts_index: keep original TimeSeries internally for all the slicing, and output TimeSeries.
             by default, Numpy array will handle the internal data workflow and Numpy array will be the output.
         :param batch_size: the number of windows to return in parallel. If ``None``, return the whole dataset.
@@ -58,8 +61,15 @@ class RollingWindowDataset:
         if isinstance(data, TimeSeries):
             data = data.align()
             self.dim = data.dim
+            if exog_data is not None:
+                assert isinstance(exog_data, TimeSeries), "Expected exog_data to be TimeSeries if data is TimeSeries"
+                exog_data = exog_data.align(reference=data.time_stamps)
         else:
             assert isinstance(data.index, pd.DatetimeIndex)
+            if exog_data is not None:
+                if isinstance(exog_data, TimeSeries):
+                    exog_data = exog_data.align(reference=data.index).to_pd()
+                assert isinstance(exog_data.index, pd.DatetimeIndex) and list(exog_data.index) == list(data.index)
             assert ts_index is False, "Only TimeSeries data support ts_index = True "
             self.dim = data.shape[1]
 
@@ -84,14 +94,15 @@ class RollingWindowDataset:
 
         self.ts_index = ts_index
         if ts_index:
-            self.data = data
-            self.target = self.data if self.autoregressive else data.univariates[data.names[target_seq_index]].to_ts()
-            self.timestamp = data.np_time_stamps
+            self.data = data.concat(exog_data, axis=1) if exog_data is not None else data
+            self.target = data if self.autoregressive else data.univariates[data.names[target_seq_index]].to_ts()
+            self.timestamp = to_pd_datetime(data.np_time_stamps)
         else:
-            data_df = data.to_pd() if isinstance(data, TimeSeries) else data
-            self.data = data_df.values
-            self.timestamp = data_df.index
-            self.target = self.data if self.autoregressive else self.data[:, target_seq_index]
+            df = data.to_pd() if isinstance(data, TimeSeries) else data
+            exog_df = data.to_pd() if isinstance(exog_data, TimeSeries) else exog_data
+            self.data = np.concatenate((df.values, exog_df.values), axis=1) if exog_data is not None else df.values
+            self.timestamp = df.index
+            self.target = df.values if self.autoregressive else df.values[:, target_seq_index]
 
     @property
     def autoregressive(self):
@@ -118,10 +129,10 @@ class RollingWindowDataset:
         past, past_ts, future, future_ts = zip(*batch)
         past = np.stack(past)
         if self.flatten:
-            past = past.reshape((len(batch), -1), order="F")
+            past = past.reshape((len(batch), -1))
         past_ts = np.stack(past_ts)
         if future is not None:
-            future = np.stack(future).reshape((len(batch), -1), order="F")
+            future = np.stack(future).reshape((len(batch), -1))
             future_ts = np.stack(future_ts)
         else:
             future, future_ts = None, None
@@ -132,9 +143,10 @@ class RollingWindowDataset:
         idx_end = idx + self.n_past
         past = self.data[idx:idx_end]
         past_timestamp = self.timestamp[idx:idx_end]
-        if self.n_future > 0:
+        if self.n_future > 0:  # predicting the future
             future = self.target[idx_end : idx_end + self.n_future]
             future_timestamp = self.timestamp[idx_end : idx_end + self.n_future]
-        else:
-            future, future_timestamp = None, None
+        else:  # autoencoding
+            future = self.target[idx:idx_end]
+            future_timestamp = self.timestamp[idx:idx_end]
         return (past, future) if self.ts_index else (past, past_timestamp, future, future_timestamp)

--- a/tests/forecast/test_boostingtrees.py
+++ b/tests/forecast/test_boostingtrees.py
@@ -8,18 +8,17 @@ import logging
 from os.path import abspath, dirname, join
 import sys
 import unittest
+import matplotlib.pyplot as plt
 
-import numpy as np
-
-from merlion.utils import TimeSeries
-from ts_datasets.forecast import SeattleTrail
 from merlion.evaluate.forecast import ForecastMetric
 from merlion.models.forecast.trees import LGBMForecaster, LGBMForecasterConfig
 from merlion.models.utils.rolling_window_dataset import RollingWindowDataset
 from merlion.transform.sequence import TransformSequence
 from merlion.transform.resample import TemporalResample
 from merlion.transform.bound import LowerUpperClip
-from merlion.transform.normalize import MinMaxNormalize
+from merlion.transform.normalize import MeanVarNormalize
+from merlion.utils import TimeSeries
+from ts_datasets.forecast import SeattleTrail
 
 logger = logging.getLogger(__name__)
 rootdir = dirname(dirname(dirname(abspath(__file__))))
@@ -37,122 +36,98 @@ class TestLGBMForecaster(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self.max_forecast_steps = 2
-        self.maxlags = 6
-        self.i = 0
-
+    def _run_test(self, univariate: bool, use_exog: bool, autoregressive: bool):
+        # Get the data and clean it up
         df, md = SeattleTrail(rootdir=join(rootdir, "data", "multivariate", "seattle_trail"))[0]
         t = int(df[md["trainval"]].index[-1].to_pydatetime().timestamp())
-        k = "BGT North of NE 70th Total"
+        target = "BGT North of NE 70th Total"
         data = TimeSeries.from_pd(df)
         cleanup = TransformSequence([TemporalResample(missing_value_policy="FFill"), LowerUpperClip(upper=300)])
         cleanup.train(data)
-        self.train_data, self.test_data = cleanup(data).bisect(t)
-        self.train_data_uni, self.test_data_uni = [d.univariates[k].to_ts() for d in [self.train_data, self.test_data]]
+        data = cleanup(data)
 
-        self.model_autoregression = LGBMForecaster(
+        # Pretend the last 2 non-target univariates are exogenous regressors if using exogenous data.
+        # Test the benefit of adding them, so don't include them in the endogenous data by default.
+        exog_cols = [c for c in data.names if c != target][-3:]
+        data_cols = [target] if univariate else [c for c in data.names if c not in exog_cols]
+        exog_data = None if not use_exog else TimeSeries([data.univariates[c] for c in exog_cols])
+        data = TimeSeries([data.univariates[c] for c in data_cols])
+        train_data, test_data = data.bisect(t)
+
+        # Set up the model
+        maxlags = 15
+        max_forecast_steps = 20
+        target_seq_idx = {k: i for i, k in enumerate(train_data.names)}[target]
+        model = LGBMForecaster(
             LGBMForecasterConfig(
-                max_forecast_steps=self.max_forecast_steps,
-                maxlags=self.maxlags,
-                target_seq_index=self.i,
-                prediction_stride=1,
+                max_forecast_steps=None if autoregressive else max_forecast_steps,
+                maxlags=maxlags,
+                target_seq_index=target_seq_idx,
+                prediction_stride=5 if univariate and autoregressive else 1 if autoregressive else max_forecast_steps,
                 n_estimators=20,
-                max_depth=5,
+                max_depth=7,
                 n_jobs=1,
-                transform=MinMaxNormalize(),
+                transform=MeanVarNormalize(),
+                exog_transform=MeanVarNormalize(),
                 invert_transform=True,
             )
         )
 
-        self.model_seq2seq = LGBMForecaster(
-            LGBMForecasterConfig(
-                max_forecast_steps=self.max_forecast_steps,
-                maxlags=self.maxlags,
-                target_seq_index=self.i,
-                prediction_stride=self.max_forecast_steps,
-                n_estimators=20,
-                max_depth=5,
-                n_jobs=1,
-                transform=MinMaxNormalize(),
-                invert_transform=True,
-            )
-        )
+        # Train model
+        yhat, _ = model.train(train_data, exog_data=exog_data)
+
+        # Check RMSE with forecast transform inversion
+        forecast, _ = model.forecast(max_forecast_steps, exog_data=exog_data)
+        rmse = ForecastMetric.RMSE.value(test_data, forecast, target_seq_index=target_seq_idx)
+        logger.info(f"Immediate forecast RMSE:  {rmse:.2f}")
+
+        # Check look-ahead RMSE using time_series_prev
+        dataset = RollingWindowDataset(test_data, target_seq_idx, maxlags, max_forecast_steps, ts_index=True)
+        test_prev, test = dataset[0]
+        pred, _ = model.forecast(test.time_stamps, time_series_prev=test_prev, exog_data=exog_data)
+        lookahead_rmse = ForecastMetric.RMSE.value(test, pred, target_seq_index=target_seq_idx)
+        logger.info(f"Look-ahead RMSE with time_series_prev:  {lookahead_rmse:.2f}")
+
+        # save and load
+        model.save(dirname=join(rootdir, "tmp", "lgbmforecaster"))
+        loaded_model = LGBMForecaster.load(dirname=join(rootdir, "tmp", "lgbmforecaster"))
+        loaded_pred, _ = loaded_model.forecast(test.time_stamps, time_series_prev=test_prev, exog_data=exog_data)
+        self.assertEqual(len(loaded_pred), len(pred))
+        self.assertAlmostEqual((pred.to_pd() - loaded_pred.to_pd()).abs().max().item(), 0, places=5)
 
     def test_forecast_multi_autoregression(self):
         print("-" * 80)
         logger.info("test_forecast_multi_autoregression" + "\n" + "-" * 80)
-        yhat, _ = self.model_autoregression.train(self.train_data)
-
-        # Check RMSE with multivariate forecast inversion
-        forecast, _ = self.model_autoregression.forecast(self.max_forecast_steps)
-        rmse = ForecastMetric.RMSE.value(self.test_data, forecast, target_seq_index=self.i)
-        logger.info(f"Immediate forecast RMSE: {rmse:.2f}")
-        # self.assertAlmostEqual(rmse, 2.9, delta=0.1)
-
-        # Check look-ahead RMSE using time_series_prev
-        dataset = RollingWindowDataset(self.test_data, self.i, self.maxlags, self.max_forecast_steps, ts_index=True)
-        testing_instance, testing_label = next(iter(dataset))
-        pred, _ = self.model_autoregression.forecast(testing_label.time_stamps, testing_instance)
-        lookahead_rmse = ForecastMetric.RMSE.value(testing_label, pred, target_seq_index=self.i)
-        logger.info(f"Look-ahead RMSE with time_series_prev: {lookahead_rmse:.2f}")
-        # self.assertAlmostEqual(lookahead_rmse, 18.9, delta=0.1)
-
-        # save and load
-        self.model_autoregression.save(dirname=join(rootdir, "tmp", "lgbmforecaster"))
-        loaded_model = LGBMForecaster.load(dirname=join(rootdir, "tmp", "lgbmforecaster"))
-        loaded_pred, _ = loaded_model.forecast(testing_label.time_stamps, testing_instance)
-        self.assertEqual(len(loaded_pred), self.max_forecast_steps)
-        self.assertAlmostEqual((pred.to_pd() - loaded_pred.to_pd()).abs().max().item(), 0, places=5)
+        self._run_test(univariate=False, autoregressive=True, use_exog=False)
 
     def test_forecast_multi_seq2seq(self):
         print("-" * 80)
         logger.info("test_forecast_multi_seq2seq" + "\n" + "-" * 80)
-        yhat, _ = self.model_seq2seq.train(self.train_data)
-
-        # Check RMSE with multivariate forecast inversion
-        forecast, _ = self.model_seq2seq.forecast(self.max_forecast_steps)
-        rmse = ForecastMetric.RMSE.value(self.test_data, forecast, target_seq_index=self.i)
-        logger.info(f"Immediate forecast RMSE: {rmse:.2f}")
-        # self.assertAlmostEqual(rmse, 3.6, delta=0.1)
-
-        # Check look-ahead RMSE using time_series_prev
-        dataset = RollingWindowDataset(self.test_data, self.i, self.maxlags, self.max_forecast_steps, ts_index=True)
-        testing_instance, testing_label = next(iter(dataset))
-        pred, _ = self.model_seq2seq.forecast(testing_label.time_stamps, testing_instance)
-        lookahead_rmse = ForecastMetric.RMSE.value(testing_label, pred, target_seq_index=self.i)
-        logger.info(f"Look-ahead RMSE with time_series_prev: {lookahead_rmse:.2f}")
-        # self.assertAlmostEqual(lookahead_rmse, 19.55, delta=0.1)
-
-        # save and load
-        self.model_seq2seq.save(dirname=join(rootdir, "tmp", "lgbmforecaster"))
-        loaded_model = LGBMForecaster.load(dirname=join(rootdir, "tmp", "lgbmforecaster"))
-        loaded_pred, _ = loaded_model.forecast(testing_label.time_stamps, testing_instance)
-        self.assertEqual(len(loaded_pred), self.max_forecast_steps)
-        self.assertAlmostEqual((pred.to_pd() - loaded_pred.to_pd()).abs().max().item(), 0, places=5)
+        self._run_test(univariate=False, autoregressive=False, use_exog=False)
 
     def test_forecast_uni(self):
         print("-" * 80)
         logger.info("test_forecast_uni" + "\n" + "-" * 80)
-        self.model_autoregression.config.prediction_stride = 2
-        yhat, _ = self.model_autoregression.train(self.train_data_uni)
+        self._run_test(univariate=True, autoregressive=True, use_exog=False)
 
-        # Check RMSE with univariate forecast inversion
-        forecast, _ = self.model_autoregression.forecast(self.max_forecast_steps)
-        rmse = ForecastMetric.RMSE.value(self.test_data, forecast, target_seq_index=self.i)
-        logger.info(f"Immediate forecast RMSE: {rmse:.2f}")
-        # self.assertAlmostEqual(rmse, 1.4, delta=0.1)
+    def test_forecast_multi_autoregression_exog(self):
+        print("-" * 80)
+        logger.info("test_forecast_multi_autoregression_exog" + "\n" + "-" * 80)
+        self._run_test(univariate=False, autoregressive=True, use_exog=True)
 
-        # Check look-ahead RMSE using time_series_prev
-        dataset = RollingWindowDataset(self.test_data_uni, self.i, self.maxlags, self.max_forecast_steps, ts_index=True)
-        testing_instance, testing_label = next(iter(dataset))
-        pred, _ = self.model_autoregression.forecast(testing_label.time_stamps, testing_instance)
-        lookahead_rmse = ForecastMetric.RMSE.value(testing_label, pred, target_seq_index=self.i)
-        logger.info(f"Look-ahead RMSE with time_series_prev: {lookahead_rmse:.2f}")
-        # self.assertAlmostEqual(lookahead_rmse, 17.3, delta=0.1)
+    def test_forecast_multi_seq2seq_exog(self):
+        print("-" * 80)
+        logger.info("test_forecast_multi_seq2seq_exog" + "\n" + "-" * 80)
+        self._run_test(univariate=False, autoregressive=False, use_exog=True)
+
+    def test_forecast_uni_exog(self):
+        print("-" * 80)
+        logger.info("test_forecast_uni_exog" + "\n" + "-" * 80)
+        self._run_test(univariate=True, autoregressive=True, use_exog=True)
 
 
 if __name__ == "__main__":
     logging.basicConfig(
-        format="%(asctime)s (%(module)s:%(lineno)d) %(levelname)s: %(message)s", stream=sys.stdout, level=logging.DEBUG
+        format="%(asctime)s (%(module)s:%(lineno)d) %(levelname)s: %(message)s", stream=sys.stdout, level=logging.INFO
     )
     unittest.main()


### PR DESCRIPTION
This pull request upgrades the `SKLearnForecasterBase` class to support exogenous regressors. This extends exogenous regressor support to tree models, and it should provide a template of how to add the feature to deep learning models in the future.