### PR TITLE
More robust detection of time series granularity.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
       with:
         max_attempts: 1
         timeout_minutes: 60
-        retry-on: error
+        retry_on: error
         command: |
           set -euxo pipefail
           # Get a comma-separated list of the directories of all python source files

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ jobs:
       env:
         PYTHON_VERSION: ${{ matrix.python-version }}
       with:
-        max_attempts: 3
+        max_attempts: 1
         timeout_minutes: 60
         retry-on: error
         command: |

--- a/docs/process_old_docs.py
+++ b/docs/process_old_docs.py
@@ -1,0 +1,75 @@
+#
+# Copyright (c) 2022 salesforce.com, inc.
+# All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+# For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+#
+"""
+Script which removes redirects from the HTML API docs & updates the version matrix on old files.
+"""
+import os
+import re
+import shutil
+
+from bs4 import BeautifulSoup as bs
+from git import Repo
+
+
+def create_version_dl(soup, prefix, current_version, all_versions):
+    dl = soup.new_tag("dl")
+    dt = soup.new_tag("dt")
+    dt.string = "Versions"
+    dl.append(dt)
+    for version in all_versions:
+        # Create the href for this version & bold it if it's the current version
+        href = soup.new_tag("a", href=f"{prefix}/{version}/index.html")
+        href.string = version
+        if version == current_version:
+            strong = soup.new_tag("strong")
+            strong.append(href)
+            href = strong
+        # Create a list item & add it to the dl
+        dd = soup.new_tag("dd")
+        dd.append(href)
+        dl.append(dd)
+    return dl
+
+
+def main():
+    # Get all the versions
+    repo = Repo(search_parent_directories=True)
+    versions = sorted([tag.name for tag in repo.tags if re.match("v[0-9].*", tag.name)], reverse=True)
+    versions = ["latest", *versions]
+
+    dirname = os.path.join(os.path.dirname(os.path.abspath(__file__)), "build", "html")
+    for version in os.listdir(dirname):
+        # If this isn't a directory containing a numbered version's API docs, delete it
+        version_root = os.path.join(dirname, version)
+        if version == "latest" or version not in versions:
+            shutil.rmtree(version_root) if os.path.isdir(version_root) else os.remove(version_root)
+            continue
+
+        # Update version matrix in HTML source versioned files
+        for subdir, _, files in os.walk(version_root):
+            html_files = [os.path.join(subdir, f) for f in files if f.endswith(".html")]
+
+            # Determine how far the version root is from the files in this directory
+            prefix = ".."
+            while subdir and subdir != version_root:
+                subdir = os.path.dirname(subdir)
+                prefix += "/.."
+
+            # Create the new description list for the version & write the new file
+            for file in html_files:
+                with open(file) as f:
+                    soup = bs(f, "html.parser")
+                version_dl = [dl for dl in soup.find_all("dl") if dl.find("dt", text="Versions")]
+                if len(version_dl) == 0:
+                    continue
+                version_dl[0].replace_with(create_version_dl(soup, prefix, version, versions))
+                with open(file, "w", encoding="utf-8") as f:
+                    f.write(str(soup))
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,7 @@
 GitPython
+beautifulsoup4
 ipykernel
-nbsphinx==0.8.7
+nbsphinx
 pandoc
 sphinx
 sphinx_autodoc_typehints

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -36,7 +36,13 @@ default_role = "any"
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ["nbsphinx", "sphinx.ext.autodoc", "sphinx.ext.autosummary", "sphinx_autodoc_typehints"]
+extensions = [
+    "nbsphinx",
+    "IPython.sphinxext.ipython_console_highlighting",
+    "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
+    "sphinx_autodoc_typehints",
+]
 
 autoclass_content = "both"  # include both class docstring and __init__
 autodoc_default_options = {
@@ -91,3 +97,4 @@ if current_version == "latest" or packaging.version.parse(current_version) > pac
     exclude_patterns = ["examples"]
 else:
     exclude_patterns = ["tutorials"]
+exclude_patterns += ["**.ipynb_checkpoints"]

--- a/merlion/models/base.py
+++ b/merlion/models/base.py
@@ -24,7 +24,7 @@ from merlion.transform.base import TransformBase, Identity
 from merlion.transform.factory import TransformFactory
 from merlion.transform.normalize import Rescale, MeanVarNormalize
 from merlion.transform.sequence import TransformSequence
-from merlion.utils.time_series import assert_equal_timedeltas, to_pd_datetime, TimeSeries
+from merlion.utils.time_series import assert_equal_timedeltas, to_pd_datetime, infer_granularity, TimeSeries
 from merlion.utils.misc import AutodocABCMeta, ModelConfigMeta
 
 logger = logging.getLogger(__name__)
@@ -169,6 +169,7 @@ class ModelBase(metaclass=AutodocABCMeta):
         self.config = copy.copy(config)
         self.last_train_time = None
         self.timedelta = None
+        self.timedelta_offset = pd.to_timedelta(0)
         self.train_data = None
 
     def reset(self):
@@ -304,12 +305,10 @@ class ModelBase(metaclass=AutodocABCMeta):
 
         # Make sure timestamps are equally spaced if needed (e.g. for ARIMA)
         t = train_data.time_stamps
+        self.timedelta, self.timedelta_offset = infer_granularity(t, return_offset=True)
         if self.require_even_sampling:
-            assert_equal_timedeltas(train_data.univariates[train_data.names[0]])
+            assert_equal_timedeltas(train_data.univariates[train_data.names[0]], self.timedelta, self.timedelta_offset)
             assert train_data.is_aligned
-            self.timedelta = pd.infer_freq(to_pd_datetime(t))
-        else:
-            self.timedelta = t[1] - t[0]
         self.last_train_time = t[-1]
         return train_data.align() if self.auto_align else train_data
 

--- a/merlion/models/forecast/base.py
+++ b/merlion/models/forecast/base.py
@@ -124,35 +124,30 @@ class ForecasterBase(ModelBase):
         if isinstance(time_stamps, (int, float)):
             n = int(time_stamps)
             assert self.max_forecast_steps is None or n <= self.max_forecast_steps
-            resampled = pd.date_range(start=t0, periods=n + 1, freq=dt)[1:] + offset
-            tf = resampled[-1]
+            resampled = pd.date_range(start=t0, periods=n + 1, freq=dt) + offset
+            resampled = resampled[1:] if resampled[0] == t0 else resampled[:-1]
             time_stamps = to_timestamp(resampled)
 
         elif not self.require_even_sampling:
             resampled = to_pd_datetime(time_stamps)
-            tf = resampled[-1]
 
         # Handle the cases where we don't have a max_forecast_steps
         elif self.max_forecast_steps is None:
             tf = to_pd_datetime(time_stamps[-1])
-            resampled = pd.date_range(start=t0, end=tf, freq=dt)[1:]
-            if resampled[-1] < tf:
-                extra = pd.date_range(start=resampled[-1], periods=2, freq=dt)[1:]
-                resampled = resampled.union(extra)
-            resampled = resampled + offset
+            resampled = pd.date_range(start=t0, end=tf + dt, freq=dt) + offset
+            resampled = resampled[1:] if resampled[0] == t0 else resampled[:-1]
 
         # Handle the case where we do have a max_forecast_steps
         else:
-            resampled = pd.date_range(start=t0, periods=self.max_forecast_steps + 1, freq=dt)[1:] + offset
-            tf = resampled[-1]
-            n = sum(t < to_pd_datetime(time_stamps[-1]) for t in resampled)
-            resampled = resampled[: n + 1]
+            resampled = pd.date_range(start=t0, periods=self.max_forecast_steps + 1, freq=dt) + offset
+            resampled = resampled[1:] if resampled[0] == t0 else resampled[:-1]
+            resampled = resampled[: sum(resampled <= to_pd_datetime(time_stamps[-1]))]
 
+        tf = resampled[-1]
         assert to_pd_datetime(time_stamps[0]) >= t0 and to_pd_datetime(time_stamps[-1]) <= tf, (
             f"Expected `time_stamps` to be between {t0} and {tf}, but `time_stamps` ranges "
             f"from {to_pd_datetime(time_stamps[0])} to {to_pd_datetime(time_stamps[-1])}"
         )
-
         return to_timestamp(resampled).tolist()
 
     def train_pre_process(

--- a/merlion/models/forecast/base.py
+++ b/merlion/models/forecast/base.py
@@ -144,7 +144,7 @@ class ForecasterBase(ModelBase):
         else:
             resampled = pd.date_range(start=t0, periods=self.max_forecast_steps + 1, freq=dt) + offset
             resampled = resampled[1:] if resampled[0] == t0 else resampled[:-1]
-            resampled = resampled[: sum(resampled <= to_pd_datetime(time_stamps[-1]))]
+            resampled = resampled[: 1 + sum(resampled < to_pd_datetime(time_stamps[-1]))]
 
         tf = resampled[-1]
         assert to_pd_datetime(time_stamps[0]) >= t0 and to_pd_datetime(time_stamps[-1]) <= tf, (

--- a/merlion/models/forecast/base.py
+++ b/merlion/models/forecast/base.py
@@ -114,7 +114,7 @@ class ForecasterBase(ModelBase):
         )
 
         # Determine timedelta & initial time of forecast
-        dt = self.timedelta
+        dt, offset = self.timedelta, self.timedelta_offset
         if time_series_prev is not None and not time_series_prev.is_empty():
             t0 = to_pd_datetime(time_series_prev.tf)
         else:
@@ -124,7 +124,7 @@ class ForecasterBase(ModelBase):
         if isinstance(time_stamps, (int, float)):
             n = int(time_stamps)
             assert self.max_forecast_steps is None or n <= self.max_forecast_steps
-            resampled = pd.date_range(start=t0, periods=n + 1, freq=dt)[1:]
+            resampled = pd.date_range(start=t0, periods=n + 1, freq=dt)[1:] + offset
             tf = resampled[-1]
             time_stamps = to_timestamp(resampled)
 
@@ -139,10 +139,11 @@ class ForecasterBase(ModelBase):
             if resampled[-1] < tf:
                 extra = pd.date_range(start=resampled[-1], periods=2, freq=dt)[1:]
                 resampled = resampled.union(extra)
+            resampled = resampled + offset
 
         # Handle the case where we do have a max_forecast_steps
         else:
-            resampled = pd.date_range(start=t0, periods=self.max_forecast_steps + 1, freq=dt)[1:]
+            resampled = pd.date_range(start=t0, periods=self.max_forecast_steps + 1, freq=dt)[1:] + offset
             tf = resampled[-1]
             n = sum(t < to_pd_datetime(time_stamps[-1]) for t in resampled)
             resampled = resampled[: n + 1]

--- a/merlion/models/forecast/base.py
+++ b/merlion/models/forecast/base.py
@@ -134,8 +134,11 @@ class ForecasterBase(ModelBase):
         # Handle the cases where we don't have a max_forecast_steps
         elif self.max_forecast_steps is None:
             tf = to_pd_datetime(time_stamps[-1])
-            resampled = pd.date_range(start=t0, end=tf + dt, freq=dt) + offset
-            resampled = resampled[1:] if resampled[0] == t0 else resampled[:-1]
+            resampled = pd.date_range(start=t0, end=tf + 2 * dt, freq=dt) + offset
+            if resampled[0] == t0:
+                resampled = resampled[1:]
+            if len(resampled) > 1 and resampled[-2] >= tf:
+                resampled = resampled[:-1]
 
         # Handle the case where we do have a max_forecast_steps
         else:

--- a/merlion/models/forecast/prophet.py
+++ b/merlion/models/forecast/prophet.py
@@ -189,12 +189,6 @@ class Prophet(ForecasterExogBase, SeasonalityModel):
                 logger.debug(f"Add seasonality {str(p)} ({p * dt})")
                 self.model.add_seasonality(name=f"extra_season_{p}", period=period, fourier_order=p)
 
-    def resample_time_stamps(self, time_stamps: Union[int, List[int]], time_series_prev: TimeSeries = None):
-        if isinstance(time_stamps, (int, float)):
-            times = pd.date_range(start=self.last_train_time, freq=self.timedelta, periods=int(time_stamps + 1))[1:]
-            time_stamps = to_timestamp(times)
-        return time_stamps
-
     def _add_exog_data(self, data: pd.DataFrame, exog_data: pd.DataFrame):
         df = pd.DataFrame(data[self.target_name].rename("y"))
         if exog_data is not None:

--- a/merlion/models/forecast/smoother.py
+++ b/merlion/models/forecast/smoother.py
@@ -293,7 +293,7 @@ class MSES(ForecasterBase):
             )
 
         new_data = TimeSeries.from_pd(new_data).univariates[name]
-        assert_equal_timedeltas(new_data, self.timedelta)
+        assert_equal_timedeltas(new_data, self.timedelta, self.timedelta_offset)
         next_train_time = self.last_train_time + self.timedelta
         if to_pd_datetime(new_data.t0) > next_train_time:
             logger.warning(

--- a/merlion/transform/resample.py
+++ b/merlion/transform/resample.py
@@ -119,7 +119,9 @@ class TemporalResample(TransformBase):
 
     def train(self, time_series: TimeSeries):
         if self.trainable_granularity:
-            self.granularity = infer_granularity(time_series.np_time_stamps)
+            granularity = infer_granularity(time_series.np_time_stamps)
+            logger.warning(f"Inferred granularity {granularity}")
+            self.granularity = granularity
 
         if self.trainable_granularity or self.origin is None:
             t0, tf = time_series.t0, time_series.tf

--- a/merlion/transform/resample.py
+++ b/merlion/transform/resample.py
@@ -11,10 +11,8 @@ into vectors.
 
 from collections import OrderedDict
 import logging
-from typing import List, Tuple, Union
-
+from typing import Union
 import numpy as np
-import pandas as pd
 
 from merlion.transform.base import TransformBase, InvertibleTransformBase
 from merlion.utils import UnivariateTimeSeries, TimeSeries

--- a/merlion/transform/resample.py
+++ b/merlion/transform/resample.py
@@ -15,14 +15,12 @@ from typing import List, Tuple, Union
 
 import numpy as np
 import pandas as pd
-from pandas.tseries.frequencies import to_offset
 
 from merlion.transform.base import TransformBase, InvertibleTransformBase
 from merlion.utils import UnivariateTimeSeries, TimeSeries
 from merlion.utils.resample import (
+    infer_granularity,
     granularity_str_to_seconds,
-    get_gcd_timedelta,
-    to_pd_datetime,
     AlignPolicy,
     AggregationPolicy,
     MissingValuePolicy,
@@ -51,31 +49,20 @@ class TemporalResample(TransformBase):
 
         :param granularity: The granularity at which we want to resample.
         :param origin: The time stamp defining the offset to start at.
-        :param trainable_granularity: Whether the granularity is trainable,
-            i.e. train() will set it to the GCD timedelta of a time series.
-            If ``None`` (default), it will be trainable only if no granularity is
-            explicitly given.
+        :param trainable_granularity: Whether  we will automatically infer the granularity of the time series.
+            If ``None`` (default), it will be trainable only if no granularity is explicitly given.
         :param remove_non_overlapping: If ``True``, we will only keep the portions
             of the univariates that overlap with each other. For example, if we
             have 3 univariates which span timestamps [0, 3600], [60, 3660], and
             [30, 3540], we will only keep timestamps in the range [60, 3540]. If
             ``False``, we will keep all timestamps produced by the resampling.
-        :param aggregation_policy: The policy we will use to aggregate multiple
-            values in a window (downsampling).
-        :param missing_value_policy: The policy we will use to impute missing
-            values (upsampling).
+        :param aggregation_policy: The policy we will use to aggregate multiple values in a window (downsampling).
+        :param missing_value_policy: The policy we will use to impute missing values (upsampling).
         """
         super().__init__()
-        if not isinstance(granularity, (int, float)):
-            try:
-                granularity = granularity_str_to_seconds(granularity)
-            except:
-                pass
         self.granularity = granularity
         self.origin = origin
-        if trainable_granularity is None:
-            trainable_granularity = granularity is None
-        self.trainable_granularity = trainable_granularity
+        self.trainable_granularity = (granularity is None) if trainable_granularity is None else trainable_granularity
         self.remove_non_overlapping = remove_non_overlapping
         self.aggregation_policy = aggregation_policy
         self.missing_value_policy = missing_value_policy
@@ -101,7 +88,7 @@ class TemporalResample(TransformBase):
             try:
                 granularity = granularity_str_to_seconds(granularity)
             except:
-                pass
+                granularity = getattr(granularity, "freqstr", granularity)
         self._granularity = granularity
 
     @property
@@ -132,16 +119,7 @@ class TemporalResample(TransformBase):
 
     def train(self, time_series: TimeSeries):
         if self.trainable_granularity:
-            time_stamps = time_series.time_stamps
-            freq = pd.infer_freq(to_pd_datetime(time_stamps))
-            if freq is not None:
-                try:
-                    self.granularity = pd.to_timedelta(to_offset(freq)).total_seconds()
-                except:
-                    self.granularity = freq
-            else:
-                self.granularity = get_gcd_timedelta(time_stamps)
-                logger.warning(f"Inferred granularity {pd.to_timedelta(self.granularity, unit='s')}")
+            self.granularity = infer_granularity(time_series.np_time_stamps)
 
         if self.trainable_granularity or self.origin is None:
             t0, tf = time_series.t0, time_series.tf

--- a/merlion/utils/resample.py
+++ b/merlion/utils/resample.py
@@ -102,7 +102,7 @@ def granularity_str_to_seconds(granularity: Union[str, float, int, None]) -> Uni
     return (ms / 1000).item()
 
 
-def get_date_offset(time_stamps, reference):
+def get_date_offset(time_stamps: pd.DatetimeIndex, reference: pd.DatetimeIndex) -> pd.DateOffset:
     """
     Returns the date offset one must add to ``time_stamps`` so its last timestamp aligns with that of ``reference``.
     """

--- a/merlion/utils/time_series.py
+++ b/merlion/utils/time_series.py
@@ -971,10 +971,13 @@ class TimeSeries:
             new_df = aggregation_policy.value(new_df)
             new_df = missing_value_policy.value(new_df)
 
-            # Add the date offset ONLY if we need it, e.g. to adjust monthly granularities
+            # Add the date offset only if we're resampling to a non-fixed granularity
             offset = get_date_offset(time_stamps=new_df.index, reference=df.index)
-            if offset.days != 0 or offset.months != 0:
-                new_df.index += offset
+            if isinstance(granularity, pd.DateOffset):
+                try:
+                    granularity.nanos
+                except ValueError:
+                    new_df.index += offset
 
             # Do any forward-filling/back-filling to cover all the indices
             return TimeSeries.from_pd(new_df[df.index[0] : df.index[-1]].ffill().bfill(), check_times=False)

--- a/merlion/utils/time_series.py
+++ b/merlion/utils/time_series.py
@@ -944,15 +944,19 @@ class TimeSeries:
                     f"so we are using alignment policy FixedGranularity."
                 )
 
-            # Get the granularity in seconds, if one is specified. Otherwise,
-            # find the GCD granularity of  all the timedeltas that appear in any
-            # of the univariate series.
+            # Get the granularity in seconds, if one is specified and the granularity is a fixed number of seconds.
+            # Otherwise, infer the granularity. If we have a non-fixed granularity, record that fact.
+            fixed_granularity = True
             if granularity is None:
                 granularity = infer_granularity(self.time_stamps)
             try:
                 granularity = pd.to_timedelta(granularity, unit="s")
-            except:
+            except ValueError:
                 granularity = to_offset(granularity)
+                try:
+                    granularity.nanos
+                except ValueError:
+                    fixed_granularity = False
 
             # Remove non-overlapping portions of univariates if desired
             df = self.to_pd()
@@ -965,19 +969,19 @@ class TimeSeries:
             if origin is None and isinstance(granularity, pd.Timedelta):
                 elapsed = df.index[-1] - df.index[0]
                 origin = df.index[0] + elapsed % granularity
-            new_df = df.resample(granularity, origin=to_pd_datetime(origin), label="right", closed="right")
+            direction = None if not fixed_granularity else "right"
+            new_df = df.resample(granularity, origin=to_pd_datetime(origin), label=direction, closed=direction)
 
             # Apply aggregation & missing value imputation policies
             new_df = aggregation_policy.value(new_df)
-            new_df = missing_value_policy.value(new_df)
+            if missing_value_policy is MissingValuePolicy.Interpolate and not fixed_granularity:
+                new_df = new_df.interpolate()
+            else:
+                new_df = missing_value_policy.value(new_df)
 
             # Add the date offset only if we're resampling to a non-fixed granularity
-            offset = get_date_offset(time_stamps=new_df.index, reference=df.index)
-            if isinstance(granularity, pd.DateOffset):
-                try:
-                    granularity.nanos
-                except ValueError:
-                    new_df.index += offset
+            if not fixed_granularity:
+                new_df.index += get_date_offset(time_stamps=new_df.index, reference=df.index)
 
             # Do any forward-filling/back-filling to cover all the indices
             return TimeSeries.from_pd(new_df[df.index[0] : df.index[-1]].ffill().bfill(), check_times=False)

--- a/merlion/utils/time_series.py
+++ b/merlion/utils/time_series.py
@@ -22,6 +22,7 @@ from merlion.utils.resample import (
     AggregationPolicy,
     AlignPolicy,
     MissingValuePolicy,
+    get_date_offset,
     infer_granularity,
     reindex_df,
     to_pd_datetime,
@@ -964,12 +965,12 @@ class TimeSeries:
             if origin is None and isinstance(granularity, pd.Timedelta):
                 elapsed = df.index[-1] - df.index[0]
                 origin = df.index[0] + elapsed % granularity
-            origin = to_pd_datetime(origin)
-            new_df = df.resample(granularity, origin=origin, label="right", closed="right")
+            new_df = df.resample(granularity, origin=to_pd_datetime(origin), closed="right")
 
             # Apply aggregation & missing value imputation policies, and make sure we don't hallucinate new data
             new_df = aggregation_policy.value(new_df)
             new_df = missing_value_policy.value(new_df)
+            new_df.index += get_date_offset(time_stamps=new_df.index, reference=df.index)
             new_df = new_df[df.index[0] : df.index[-1]]
             return TimeSeries.from_pd(new_df.ffill().bfill(), check_times=False)
 

--- a/tests/forecast/test_prophet.py
+++ b/tests/forecast/test_prophet.py
@@ -29,9 +29,9 @@ class TestProphet(unittest.TestCase):
         # arrange
         config = ProphetConfig()
         prophet = Prophet(config)
-        prophet.last_train_time = pd._libs.tslibs.timestamps.Timestamp(year=2022, month=1, day=1)
-        prophet.timedelta = pd._libs.tslibs.timedeltas.Timedelta(days=1)
-        target = np.array([to_timestamp(pd._libs.tslibs.timestamps.Timestamp(year=2022, month=1, day=2))])
+        prophet.last_train_time = pd.Timestamp(year=2022, month=1, day=1)
+        prophet.timedelta = pd.Timedelta(days=1)
+        target = np.array([to_timestamp(pd.Timestamp(year=2022, month=1, day=2))])
 
         # act
         output = prophet.resample_time_stamps(time_stamps=1)

--- a/tests/transform/test_resample.py
+++ b/tests/transform/test_resample.py
@@ -1,15 +1,63 @@
 #
-# Copyright (c) 2021 salesforce.com, inc.
+# Copyright (c) 2022 salesforce.com, inc.
 # All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 # For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
 #
 import logging
+import pandas as pd
 import numpy as np
+import sys
 import unittest
 
 from merlion.utils import TimeSeries, UnivariateTimeSeries
-from merlion.transform.resample import Shingle
+from merlion.transform.resample import Shingle, TemporalResample
+
+logger = logging.getLogger(__name__)
+
+
+class TestResample(unittest.TestCase):
+    def _test_granularity(self, granularity, offset=pd.to_timedelta(0)):
+        # 6:30am on the 3rd of every other month
+        index = pd.date_range("1970-12-01", "2010-01-01", freq=granularity) + offset
+        full_df = pd.DataFrame(range(len(index)), index=index, columns=["value"])
+
+        # drop some indices to induce missing data, and then split into train/test
+        df = full_df.drop(index[[3, 4, 5, 12, 15, 16, -3, -2]])
+        train = TimeSeries.from_pd(df.iloc[:-5])
+        test = TimeSeries.from_pd(df.iloc[-5:])
+
+        # train the temporal resample & ensure it has the right granularity
+        transform = TemporalResample()
+        transform.train(train)
+        granularity = TemporalResample(granularity=granularity).granularity
+        self.assertEqual(transform.granularity, granularity)
+
+        # Make sure the resampled values are correct
+        resampled_test = transform(test).to_pd()["value"]
+        full_test = full_df.loc[resampled_test.index[0] :, "value"]
+        self.assertSequenceEqual(resampled_test.index.to_list(), full_test.index.to_list())
+        self.assertSequenceEqual(resampled_test.values.tolist(), full_test.values.tolist())
+
+    def test_fixed_granularity(self):
+        self._test_granularity(granularity="1h")
+        self._test_granularity(granularity="3h", offset=pd.Timedelta(hours=1, minutes=13))
+
+    def test_two_month(self):
+        logger.info("Testing start-of-month resampling...")
+        self._test_granularity(granularity="2MS")
+        logger.info("Testing start-of-month resampling with an offset...")
+        self._test_granularity(granularity="2MS", offset=pd.Timedelta(days=3, hours=6, minutes=30))
+        logger.info("Testing end-of-month resampling...")
+        self._test_granularity(granularity="2M")
+        logger.info("Testing end-of-month resampling...")
+        self._test_granularity(granularity="2M", offset=-pd.Timedelta(days=7, hours=7))
+
+    def test_yearly(self):
+        logger.info("Testing start-of-year resampling...")
+        self._test_granularity(granularity="12MS", offset=pd.to_timedelta(0))
+        logger.info("Testing end-of-year resampling...")
+        self._test_granularity(granularity="12M", offset=pd.to_timedelta(0))
 
 
 class TestShingle(unittest.TestCase):
@@ -60,4 +108,7 @@ class TestShingle(unittest.TestCase):
 
 
 if __name__ == "__main__":
+    logging.basicConfig(
+        format="%(asctime)s (%(module)s:%(lineno)d) %(levelname)s: %(message)s", stream=sys.stdout, level=logging.INFO
+    )
     unittest.main()

--- a/ts_datasets/ts_datasets/forecast/m4.py
+++ b/ts_datasets/ts_datasets/forecast/m4.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2021 salesforce.com, inc.
+# Copyright (c) 2022 salesforce.com, inc.
 # All rights reserved.
 # SPDX-License-Identifier: BSD-3-Clause
 # For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
@@ -58,13 +58,9 @@ class M4(BaseDataset):
                 "the max length of yearly data is 841 which is too big to convert to "
                 "timestamps, we fallback to quarterly frequency"
             )
-            freq = "13W"
-        elif subset == "Quarterly":
-            freq = "13W"
-        elif subset == "Monthly":
-            freq = "30D"
+            self.freq = "Q"
         else:
-            freq = subset[0]
+            self.freq = subset[0]
 
         train_csv = os.path.join(rootdir, f"train/{subset}-train.csv")
         if not os.path.isfile(train_csv):
@@ -73,19 +69,19 @@ class M4(BaseDataset):
         if not os.path.isfile(test_csv):
             download(os.path.join(rootdir, "test"), self.url, f"{subset}-test", "Test")
 
-        train_set = pd.read_csv(train_csv).set_index("V1")
-        test_set = pd.read_csv(test_csv).set_index("V1")
-        for i in tqdm(range(train_set.shape[0])):
-            ntrain = train_set.iloc[i, :].dropna().shape[0]
-            sequence = pd.concat((train_set.iloc[i, :].dropna(), test_set.iloc[i, :].dropna()))
-            # raw data do not follow consistent timestamp format
-            sequence.index = pd.date_range(start=0, periods=sequence.shape[0], freq=freq)
-            sequence = sequence.to_frame()
+        self.train_set = pd.read_csv(train_csv).set_index("V1")
+        self.test_set = pd.read_csv(test_csv).set_index("V1")
 
-            metadata = pd.DataFrame({"trainval": sequence.index < sequence.index[ntrain]}, index=sequence.index)
+    def __getitem__(self, i):
+        train, test = self.train_set.iloc[i].dropna(), self.test_set.iloc[i].dropna()
+        ts = pd.concat((train, test)).to_frame()
+        # raw data do not follow consistent timestamp format
+        ts.index = pd.date_range(start=0, periods=ts.shape[0], freq=self.freq)
+        md = pd.DataFrame({"trainval": ts.index < ts.index[len(train)]}, index=ts.index)
+        return ts, md
 
-            self.metadata.append(metadata)
-            self.time_series.append(sequence)
+    def __len__(self):
+        return len(self.train_set)
 
 
 def download(datapath, url, name, split=None):


### PR DESCRIPTION
Previously, we would detect the granularity of a time series as the GCD of all timedeltas found in the time series (assuming pandas couldn't infer the granularity on its own). However, this behavior fails for time series with missing data that are sampled at granularities that aren't an exact number of seconds, e.g. monthly time series would be resampled to a daily granularity because months are of inconsistent length.

This PR uses the most commonly observed timedelta (instead of the GCD), and it also checks whether a k-month granularity is a better fit for the time series than a n-day granularity. To handle non-fixed granularities (e.g. months or years), we also start maintaining memory of an _offset_. The general approach is then to resample the time series using the detected granularity, and then add any offset necessary to recover the original timestamps. This is necessary because resampling using the monthly granularities in `pandas` only return time series sampled on specific days of the month (typically first/last). Maintaining the offset allows us to support more general time series.