### PR TITLE
[Bugfix] Change FloatTensor to tensor

### DIFF
--- a/merlion/models/anomaly/autoencoder.py
+++ b/merlion/models/anomaly/autoencoder.py
@@ -119,7 +119,7 @@ class AutoEncoder(DetectorBase):
         for epoch in range(self.num_epochs):
             total_loss = 0
             for i, (batch, _, _, _) in enumerate(loader):
-                batch = torch.FloatTensor(batch, device=self.device)
+                batch = torch.tensor(batch, dtype=torch.float, device=self.device)
                 loss = self.model.loss(batch)
                 optimizer.zero_grad()
                 loss.backward()
@@ -144,7 +144,7 @@ class AutoEncoder(DetectorBase):
         )
         scores = []
         for y, _, _, _ in loader:
-            y = torch.FloatTensor(y, device=self.device)
+            y = torch.tensor(y, dtype=torch.float, device=self.device)
             scores.append(self.model(y).cpu().data.numpy())
         scores = np.concatenate([np.ones(self.k - 1) * scores[0][0], *scores])
         return pd.DataFrame(scores[-len(time_series) :], index=time_series.index)

--- a/merlion/models/anomaly/lstm_ed.py
+++ b/merlion/models/anomaly/lstm_ed.py
@@ -124,7 +124,7 @@ class LSTMED(DetectorBase):
         for epoch in range(self.num_epochs):
             total_loss = 0
             for batch, _, _, _ in train_loader:
-                batch = torch.FloatTensor(batch, device=self.device)
+                batch = torch.tensor(batch, dtype=torch.float, device=self.device)
                 output = self.lstmed(batch)
                 loss = loss_func(output, batch)
                 self.lstmed.zero_grad()
@@ -149,7 +149,7 @@ class LSTMED(DetectorBase):
         )
         scores, outputs = [], []
         for idx, (batch, _, _, _) in enumerate(data_loader):
-            batch = torch.FloatTensor(batch, device=self.device)
+            batch = torch.tensor(batch, dtype=torch.float, device=self.device)
             output = self.lstmed(batch)
             error = nn.L1Loss(reduction="none")(output, batch)
             score = np.mean(error.view(-1, ts.shape[1]).data.cpu().numpy(), axis=1)

--- a/merlion/models/anomaly/vae.py
+++ b/merlion/models/anomaly/vae.py
@@ -140,7 +140,7 @@ class VAE(DetectorBase):
         for epoch in range(self.num_epochs):
             total_loss = 0
             for i, (batch, _, _, _) in enumerate(loader):
-                x = torch.FloatTensor(batch, device=self.device)
+                x = torch.tensor(batch, dtype=torch.float, device=self.device)
                 recon_x, mu, log_var, _ = self.model(x, None)
                 recon_loss = loss_func(x, recon_x)
                 kld_loss = -0.5 * torch.mean(torch.sum(1 + log_var - mu ** 2 - log_var.exp(), dim=1), dim=0)
@@ -168,7 +168,7 @@ class VAE(DetectorBase):
         ys, rs = [], []
         for y, _, _, _ in loader:
             ys.append(y)
-            y = torch.FloatTensor(y, device=self.device)
+            y = torch.tensor(y, dtype=torch.float, device=self.device)
             r = np.zeros(y.shape)
             for _ in range(self.num_eval_samples):
                 recon_y, _, _, _ = self.model(y, None)

--- a/merlion/models/forecast/lstm.py
+++ b/merlion/models/forecast/lstm.py
@@ -119,7 +119,7 @@ class Corpus(Dataset):
 
     def __getitem__(self, idx):
         max_idx = idx + (self.seq_len - 1) * self.stride + 1
-        return torch.FloatTensor(self.sequence[idx : max_idx : self.stride])
+        return torch.tensor(self.sequence[idx : max_idx : self.stride], dtype=torch.float)
 
 
 class _LSTMBase(nn.Module):
@@ -372,7 +372,7 @@ class LSTM(ForecasterBase):
         # Since we've updated the transform's granularity, re-apply it on
         # the original train data (self.train_data) before proceeding.
         ts = self.transform(self.train_data).univariates[self.target_name]
-        vals = torch.FloatTensor([ts.np_values])
+        vals = torch.tensor([ts.np_values], dtype=torch.float)
         if torch.cuda.is_available():
             vals = vals.cuda()
 
@@ -397,7 +397,7 @@ class LSTM(ForecasterBase):
         #      (self.seq_len - self.max_forecast_steps) time steps?
         #      This would better match the training distribution
         time_series_prev = time_series_prev.iloc[:, self.target_seq_index]
-        vals = torch.FloatTensor([time_series_prev.values])
+        vals = torch.tensor([time_series_prev.values], dtype=torch.float)
         if torch.cuda.is_available():
             vals = vals.cuda()
             self.model.cuda()


### PR DESCRIPTION
### Why
On my environment
```
# pip list | grep  salesforce
salesforce-merlion                2.0.0        /root/workspace/outlier_detection/Merlion
# pip list | grep torch
pytorch-lightning                 1.4.8
torch                             1.9.1+cu111
torchaudio                        0.9.1
torchfile                         0.1.0
torchmetrics                      0.9.2
torchvision                       0.10.1+cu111
```
When I use `merlion.models.anomaly.autoencoder.AutoEncoder` I got the error below
```
Traceback (most recent call last):
  File "example.py", line 14, in <module>
    model.train(train_data=train_data)
  File "/root/workspace/outlier_detection/Merlion/merlion/models/anomaly/base.py", line 200, in train
    self._train, train_data=train_data, train_config=train_config, anomaly_labels=anomaly_labels
  File "/root/workspace/outlier_detection/Merlion/merlion/utils/misc.py", line 177, in call_with_accepted_kwargs
    return fn(**kwargs)
  File "/root/workspace/outlier_detection/Merlion/merlion/models/anomaly/autoencoder.py", line 132, in _train
    return self._get_anomaly_score(train_data)
  File "/root/workspace/outlier_detection/Merlion/merlion/models/anomaly/autoencoder.py", line 148, in _get_anomaly_score
    y = torch.FloatTensor(y, device=self.device)
RuntimeError: legacy constructor expects device type: cpu but device type: cuda was passed
```
This is because `torch.FloatTensorr` is a legacy constructor. see https://github.com/pytorch/pytorch/issues/20122

### What
- Changed `torch.FloatTensor` to `torch.tensor` to fix the error