### PR TITLE
Update nab.py

### DIFF
--- a/ts_datasets/ts_datasets/anomaly/nab.py
+++ b/ts_datasets/ts_datasets/anomaly/nab.py
@@ -83,8 +83,8 @@ class NAB(TSADBaseDataset):
             if len(df["timestamp"][df["timestamp"].diff() == datetime.timedelta(0)]) != 0:
                 df = df.drop_duplicates(subset="timestamp", keep="first")
                 logger.warning(f"Time series {csv} (index {i}) has timestamp duplicates. Kept first values.")
-
-            all_dt = np.unique(np.diff(df["timestamp"])).astype(np.int64)
+                
+            all_dt = np.unique(np.diff(df["timestamp"]))
             gcd_dt = all_dt[0]
             for dt in all_dt[1:]:
                 gcd_dt = np.gcd(gcd_dt, dt)


### PR DESCRIPTION

![image](https://github.com/salesforce/Merlion/assets/48086850/3feb8780-3047-412a-98c9-bb209f873e19)

explicit conversion in 
explicit conversion on line 87 on all_dt variable  lead to TypeError: int() argument must be a string, a bytes-like object or a real number, not 'Timedelta'. This was encountered on google cola.  This error is fixed by removing explicit type conversion operation  , done using  astype(). 