### PR TITLE
 feat : use --no-cache-dir flag to pip in dockerfiles to save space

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,4 +11,4 @@ RUN rm -rf /var/lib/apt/lists/* && \
 COPY *.md ./
 COPY setup.py ./
 COPY merlion merlion
-RUN pip install "./"
+RUN pip install --no-cache-dir "./"

--- a/docker/dashboard/Dockerfile
+++ b/docker/dashboard/Dockerfile
@@ -11,5 +11,5 @@ RUN rm -rf /var/lib/apt/lists/* && \
 COPY *.md ./
 COPY setup.py ./
 COPY merlion merlion
-RUN pip install gunicorn "./[dashboard]"
+RUN pip install --no-cache-dir gunicorn "./[dashboard]"
 CMD gunicorn -b 0.0.0.0:80 merlion.dashboard.server:server

--- a/docker/spark-on-k8s/Dockerfile
+++ b/docker/spark-on-k8s/Dockerfile
@@ -9,7 +9,7 @@ ENV PYTHONPATH="${SPARK_HOME}/python/lib/pyspark.zip:${SPARK_HOME}/python/lib/py
 COPY *.md ./
 COPY setup.py ./
 COPY merlion merlion
-RUN pip install pyarrow "./"
+RUN pip install --no-cache-dir pyarrow "./"
 
 # Copy Merlion pyspark apps
 COPY spark_apps /opt/spark/apps


### PR DESCRIPTION
using the "--no-cache-dir" flag in pip install, make sure downloaded packages by pip don't cache on the system. This is a best practice that makes sure to fetch from a repo instead of using a local cached one. Further, in the case of Docker Containers, by restricting caching, we can reduce image size. In terms of stats, it depends upon the number of python packages multiplied by their respective size. e.g for heavy packages with a lot of dependencies it reduces a lot by don't cache pip packages.

Further, more detailed information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>