### PR TITLE
fix(installdashboard): add quotes around dashboard installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ The easiest way to get started is to use the GUI web-based
 [dashboard](https://opensource.salesforce.com/Merlion/merlion.dashboard.html).
 This dashboard provides a great way to quickly experiment with many models on your own custom datasets.
 To use it, install Merlion with the optional ``dashboard`` dependency (i.e.
-``pip install salesforce-merlion[dashboard]``), and call ``python -m merlion.dashboard`` from the command line.
+``pip install "salesforce-merlion[dashboard]"``), and call ``python -m merlion.dashboard`` from the command line.
 You can view the dashboard at http://localhost:8050.
 Below, we show some screenshots of the dashboard for both anomaly detection and forecasting.
 


### PR DESCRIPTION
# Context

Copy pasting the dashboard installation command resulted in this error:

```
pip install salesforce-merliondashboard 
ERROR: Could not find a version that satisfies the requirement salesforce-merliondashboard (from versions: none)
ERROR: No matching distribution found for salesforce-merliondashboard
```

# Change
Updated readme to put the dashboard installation command in quotes to avoid the error:

```
pip install "salesforce-merlion[dashboard]"
```
