### PR TITLE
fix(dockerdashboard): broken java + dash dependencies

### DIFF
--- a/docker/dashboard/Dockerfile
+++ b/docker/dashboard/Dockerfile
@@ -1,15 +1,18 @@
 FROM python:3.9-slim
 WORKDIR /opt/Merlion
 # Install Java
-RUN rm -rf /var/lib/apt/lists/* && \
-    apt-get clean && \
-    apt-get update && \
-    apt-get upgrade && \
-    apt-get install -y --no-install-recommends openjdk-11-jre-headless && \
-    rm -rf /var/lib/apt/lists/*
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    default-jre-headless \
+    && rm -rf /var/lib/apt/lists/*
 # Install Merlion from source & set up a gunicorn server
 COPY *.md ./
 COPY setup.py ./
 COPY merlion merlion
 RUN pip install gunicorn "./[dashboard]"
+
+RUN pip install 'dash_bootstrap_components<=1.7.1' --force-reinstall
+
+RUN pip install 'dash<=2.18.0' --force-reinstall
+
 CMD gunicorn -b 0.0.0.0:80 merlion.dashboard.server:server


### PR DESCRIPTION
# Context

Dockerfile for dashboard is broken

Related issue: https://github.com/salesforce/Merlion/issues/179

# Changes

Modified java install and dash version